### PR TITLE
Merge changes from upstream to fix compatibility with upcoming Heroku change

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -29,11 +29,11 @@ VENDOR_DIR="$BUILD_DIR/vendor"
 INSTALL_DIR="$VENDOR_DIR/pandoc"
 BIN_DIR="$INSTALL_DIR/bin"
 SHARE_DIR="$INSTALL_DIR/share"
-REAL_DIR="$HOME/vendor/pandoc/bin"
+RUNTIME_DIR="\$HOME/vendor/pandoc/bin"
 DEB_ARCHIVE_BINARIES="data.tar.xz"
 PANDOC_PKG="$CACHE_DIR/$PANDOC_RELEASE"
 
-mkdir -p $BUILD_DIR $CACHE_DIR $VENDOR_DIR $INSTALL_DIR $BIN_DIR $SHARE_DIR $REAL_DIR
+mkdir -p $BUILD_DIR $CACHE_DIR $VENDOR_DIR $INSTALL_DIR $BIN_DIR $SHARE_DIR
 
 verbose "BUILD_DIR: $BUILD_DIR"
 verbose "CACHE_DIR: $CACHE_DIR"
@@ -41,7 +41,7 @@ verbose "VENDOR_DIR: $VENDOR_DIR"
 verbose "INSTALL_DIR: $INSTALL_DIR"
 verbose "BIN_DIR: $BIN_DIR"
 verbose "SHARE_DIR: $SHARE_DIR"
-verbose "REAL_DIR: $REAL_DIR"
+verbose "RUNTIME_DIR: $RUNTIME_DIR"
 
 if [ -f $PANDOC_PKG ]; then
   verbose "Using cached pandoc pkg: $PANDOC_PKG"
@@ -73,7 +73,7 @@ ls -lR $BIN_DIR | indent
 
 PROFILE_PATH="$BUILD_DIR/.profile.d/pandoc.sh"
 mkdir -p $(dirname $PROFILE_PATH)
-echo "export PATH=$REAL_DIR:\$PATH" > $PROFILE_PATH
+echo "export PATH=$RUNTIME_DIR:\$PATH" > $PROFILE_PATH
 
 verbose "created $PROFILE_PATH:"
 cat $PROFILE_PATH | indent


### PR DESCRIPTION
Hi! I'm on the team that maintains Heroku's build system.

In the next week or two we plan on changing the value for `$HOME` at build time as part of moving where the build occurs, however this buildpack has been found to not be compatible with this change.

This PR merges in the fix for this compatibility issue from the upstream repository from which this repo was forked:
https://github.com/illustrativemathematics/pandoc-buildpack/pull/7

For more information, see:
https://github.com/illustrativemathematics/pandoc-buildpack/issues/6

I recommend merging this sooner rather than later, to avoid disruption with any apps that are using this buildpack for their builds.

Many thanks :-)